### PR TITLE
Adding Topsy's Otter API to flavours

### DIFF
--- a/docs/flavours.md
+++ b/docs/flavours.md
@@ -16,6 +16,8 @@
 [https://github.com/vintasoftware/tapioca-harvest](https://github.com/vintasoftware/tapioca-harvest)
 ## CrunchBase
 [https://github.com/vu3jej/tapioca-crunchbase](https://github.com/vu3jej/tapioca-crunchbase)
+## Otter
+[https://github.com/vu3jej/tapioca-otter](https://github.com/vu3jej/tapioca-otter)
 
 ### Your flavour
 Send a pull request to add new ones to the list.


### PR DESCRIPTION
This is to add Topsy's Otter API to the list of flavours. I was not sure if we are following a pattern keeping the title of the flavours to single word. So didn't mention Topsy in it.

Package uploaded to PyPI can be found here - https://pypi.python.org/pypi/tapioca-otter. Thanks! :)
