### PR TITLE
turning 'data', 'response' and 'status_code' into attributes of executor

### DIFF
--- a/tapioca/exceptions.py
+++ b/tapioca/exceptions.py
@@ -13,7 +13,7 @@ class TapiocaException(Exception):
         self.status_code = None
         self.client = client
         if client is not None:
-            self.status_code = client().response().status_code
+            self.status_code = client().status_code
 
         if not message:
             message = "response status code: {}".format(self.status_code)

--- a/tapioca/tapioca.py
+++ b/tapioca/tapioca.py
@@ -165,16 +165,19 @@ class TapiocaClientExecutor(TapiocaClient):
     def __call__(self, *args, **kwargs):
         return self._wrap_in_tapioca(self._data.__call__(*args, **kwargs))
 
+    @property
     def data(self):
         return self._data
 
+    @property
     def response(self):
         if self._response is None:
             raise Exception("This instance has no response object")
         return self._response
 
+    @property
     def status_code(self):
-        return self.response().status_code
+        return self.response.status_code
 
     def _make_request(self, request_method, *args, **kwargs):
         if 'url' not in kwargs:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -22,7 +22,7 @@ class TestTapiocaException(unittest.TestCase):
 
     @responses.activate
     def test_exception_contain_tapioca_client(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=400,
                       content_type='application/json')
@@ -36,7 +36,7 @@ class TestTapiocaException(unittest.TestCase):
 
     @responses.activate
     def test_exception_contain_status_code(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=400,
                       content_type='application/json')
@@ -50,7 +50,7 @@ class TestTapiocaException(unittest.TestCase):
 
     @responses.activate
     def test_exception_message(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=400,
                       content_type='application/json')
@@ -70,31 +70,31 @@ class TestExceptions(unittest.TestCase):
 
     @responses.activate
     def test_adapter_raises_response_process_exception_on_400s(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"erros": "Server Error"}',
                       status=400,
                       content_type='application/json')
 
-        response = requests.get(self.wrapper.test().data())
+        response = requests.get(self.wrapper.test().data)
 
         with self.assertRaises(ResponseProcessException):
             TesterClientAdapter().process_response(response)
 
     @responses.activate
     def test_adapter_raises_response_process_exception_on_500s(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"erros": "Server Error"}',
                       status=500,
                       content_type='application/json')
 
-        response = requests.get(self.wrapper.test().data())
+        response = requests.get(self.wrapper.test().data)
 
         with self.assertRaises(ResponseProcessException):
             TesterClientAdapter().process_response(response)
 
     @responses.activate
     def test_raises_request_error(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=400,
                       content_type='application/json')
@@ -104,7 +104,7 @@ class TestExceptions(unittest.TestCase):
 
     @responses.activate
     def test_raises_server_error(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       status=500,
                       content_type='application/json')
 

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -28,7 +28,7 @@ class TestSerlializer(unittest.TestCase):
 
     @responses.activate
     def test_executor_dir_returns_serializer_methods(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"date": "2014-11-13T14:53:18.694072+00:00"}',
                       status=200,
                       content_type='application/json')
@@ -48,7 +48,7 @@ class TestDeserialization(unittest.TestCase):
 
     @responses.activate
     def test_convert_to_decimal(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"decimal_value": "10.51"}',
                       status=200,
                       content_type='application/json')
@@ -59,7 +59,7 @@ class TestDeserialization(unittest.TestCase):
 
     @responses.activate
     def test_convert_to_datetime(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"date": "2014-11-13T14:53:18.694072+00:00"}',
                       status=200,
                       content_type='application/json')
@@ -75,7 +75,7 @@ class TestDeserialization(unittest.TestCase):
 
     @responses.activate
     def test_call_non_existent_conversion(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"any_data": "%#ˆ$&"}',
                       status=200,
                       content_type='application/json')
@@ -87,7 +87,7 @@ class TestDeserialization(unittest.TestCase):
     @responses.activate
     def test_call_conversion_with_no_serializer(self):
         wrapper = TesterClient()
-        responses.add(responses.GET, wrapper.test().data(),
+        responses.add(responses.GET, wrapper.test().data,
                       body='{"any_data": "%#ˆ$&"}',
                       status=200,
                       content_type='application/json')

--- a/tests/test_tapioca.py
+++ b/tests/test_tapioca.py
@@ -24,7 +24,7 @@ class TestTapiocaClient(unittest.TestCase):
 
         resource = self.wrapper.user(id='123')
 
-        self.assertEqual(resource.data(), expected_url)
+        self.assertEqual(resource.data, expected_url)
 
     def test_calling_len_on_tapioca_list(self):
         client = self.wrapper._wrap_in_tapioca([0, 1, 2])
@@ -40,11 +40,11 @@ class TestTapiocaClient(unittest.TestCase):
         client = self.wrapper._wrap_in_tapioca([0, 1, 2])
 
         for i, item in enumerate(client):
-            self.assertEqual(item().data(), i)
+            self.assertEqual(item().data, i)
 
     @responses.activate
     def test_in_operator(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": 1, "other": 2}',
                       status=200,
                       content_type='application/json')
@@ -59,7 +59,7 @@ class TestTapiocaClient(unittest.TestCase):
     def test_trasnform_camelCase_in_snake_case(self):
         next_url = 'http://api.teste.com/next_batch'
 
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data" :{"key_snake": "value", "camelCase": "data in camel case", "NormalCamelCase": "data in camel case"}, "paging": {"next": "%s"}}' % next_url,
                       status=200,
                       content_type='application/json')
@@ -67,9 +67,9 @@ class TestTapiocaClient(unittest.TestCase):
 
         response = self.wrapper.test().get()
 
-        self.assertEqual(response.data.key_snake().data(), 'value')
-        self.assertEqual(response.data.camel_case().data(), 'data in camel case')
-        self.assertEqual(response.data.normal_camel_case().data(), 'data in camel case')
+        self.assertEqual(response.data.key_snake().data, 'value')
+        self.assertEqual(response.data.camel_case().data, 'data in camel case')
+        self.assertEqual(response.data.normal_camel_case().data, 'data in camel case')
 
 
 
@@ -82,7 +82,7 @@ class TestTapiocaExecutor(unittest.TestCase):
         expected_url = 'https://api.test.com/test/'
         resource = self.wrapper.test()
 
-        self.assertEqual(resource.data(), expected_url)
+        self.assertEqual(resource.data, expected_url)
 
     def test_docs(self):
         self.assertEqual(
@@ -99,14 +99,14 @@ class TestTapiocaExecutor(unittest.TestCase):
 
         self.assertTrue(isinstance(items, TapiocaClient))
 
-        data = dict(items().data())
+        data = dict(items().data)
 
         self.assertEqual(data, {'test': 'value'})
 
     def test_is_possible_to_reverse_a_list_through_executor(self):
         client = self.wrapper._wrap_in_tapioca([0, 1, 2])
         client().reverse()
-        self.assertEqual(client().data(), [2, 1, 0])
+        self.assertEqual(client().data, [2, 1, 0])
 
     def test_cannot__getittem__(self):
         client = self.wrapper._wrap_in_tapioca([0, 1, 2])
@@ -136,7 +136,7 @@ class TestTapiocaExecutor(unittest.TestCase):
     def test_response_executor_object_has_a_response(self):
         next_url = 'http://api.teste.com/next_batch'
 
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": [{"key": "value"}], "paging": {"next": "%s"}}' % next_url,
                       status=200,
                       content_type='application/json')
@@ -149,7 +149,7 @@ class TestTapiocaExecutor(unittest.TestCase):
         response = self.wrapper.test().get()
         executor = response()
 
-        executor.response()
+        executor.response
 
         executor._response = None
 
@@ -157,18 +157,18 @@ class TestTapiocaExecutor(unittest.TestCase):
         client = self.wrapper
 
         with self.assertRaises(Exception):
-            client().response()
+            client().response
 
     @responses.activate
     def test_response_executor_has_a_status_code(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=200,
                       content_type='application/json')
 
         response = self.wrapper.test().get()
 
-        self.assertEqual(response().status_code(), 200)
+        self.assertEqual(response().status_code, 200)
 
 
 class TestTapiocaExecutorRequests(unittest.TestCase):
@@ -178,7 +178,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
 
     def test_when_executor_has_no_response(self):
         with self.assertRaises(Exception) as context:
-            self.wrapper.test().response()
+            self.wrapper.test().response
 
         exception = context.exception
 
@@ -186,18 +186,18 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
 
     @responses.activate
     def test_get_request(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=200,
                       content_type='application/json')
 
         response = self.wrapper.test().get()
 
-        self.assertEqual(response().data(), {'data': {'key': 'value'}})
+        self.assertEqual(response().data, {'data': {'key': 'value'}})
 
     @responses.activate
     def test_access_response_field(self):
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=200,
                       content_type='application/json')
@@ -206,57 +206,57 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
 
         response_data = response.data()
 
-        self.assertEqual(response_data.data(), {'key': 'value'})
+        self.assertEqual(response_data.data, {'key': 'value'})
 
     @responses.activate
     def test_post_request(self):
-        responses.add(responses.POST, self.wrapper.test().data(),
+        responses.add(responses.POST, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=201,
                       content_type='application/json')
 
         response = self.wrapper.test().post()
 
-        self.assertEqual(response().data(), {'data': {'key': 'value'}})
+        self.assertEqual(response().data, {'data': {'key': 'value'}})
 
     @responses.activate
     def test_put_request(self):
-        responses.add(responses.PUT, self.wrapper.test().data(),
+        responses.add(responses.PUT, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=201,
                       content_type='application/json')
 
         response = self.wrapper.test().put()
 
-        self.assertEqual(response().data(), {'data': {'key': 'value'}})
+        self.assertEqual(response().data, {'data': {'key': 'value'}})
 
     @responses.activate
     def test_patch_request(self):
-        responses.add(responses.PATCH, self.wrapper.test().data(),
+        responses.add(responses.PATCH, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=201,
                       content_type='application/json')
 
         response = self.wrapper.test().patch()
 
-        self.assertEqual(response().data(), {'data': {'key': 'value'}})
+        self.assertEqual(response().data, {'data': {'key': 'value'}})
 
     @responses.activate
     def test_delete_request(self):
-        responses.add(responses.DELETE, self.wrapper.test().data(),
+        responses.add(responses.DELETE, self.wrapper.test().data,
                       body='{"data": {"key": "value"}}',
                       status=201,
                       content_type='application/json')
 
         response = self.wrapper.test().delete()
 
-        self.assertEqual(response().data(), {'data': {'key': 'value'}})
+        self.assertEqual(response().data, {'data': {'key': 'value'}})
 
     @responses.activate
     def test_simple_pages_iterator(self):
         next_url = 'http://api.teste.com/next_batch'
 
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": [{"key": "value"}], "paging": {"next": "%s"}}' % next_url,
                       status=200,
                       content_type='application/json')
@@ -270,7 +270,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
 
         iterations_count = 0
         for item in response().pages():
-            self.assertIn(item.key().data(), 'value')
+            self.assertIn(item.key().data, 'value')
             iterations_count += 1
 
         self.assertEqual(iterations_count, 2)
@@ -279,7 +279,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
     def test_simple_pages_with_max_items_iterator(self):
         next_url = 'http://api.teste.com/next_batch'
 
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": [{"key": "value"}], "paging": {"next": "%s"}}' % next_url,
                       status=200,
                       content_type='application/json')
@@ -293,7 +293,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
 
         iterations_count = 0
         for item in response().pages(max_items=3, max_pages=2):
-            self.assertIn(item.key().data(), 'value')
+            self.assertIn(item.key().data, 'value')
             iterations_count += 1
 
         self.assertEqual(iterations_count, 3)
@@ -302,7 +302,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
     def test_simple_pages_with_max_pages_iterator(self):
         next_url = 'http://api.teste.com/next_batch'
 
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": [{"key": "value"}], "paging": {"next": "%s"}}' % next_url,
                       status=200,
                       content_type='application/json')
@@ -325,7 +325,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
 
         iterations_count = 0
         for item in response().pages(max_pages=3):
-            self.assertIn(item.key().data(), 'value')
+            self.assertIn(item.key().data, 'value')
             iterations_count += 1
 
         self.assertEqual(iterations_count, 7)
@@ -334,7 +334,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
     def test_simple_pages_max_page_zero_iterator(self):
         next_url = 'http://api.teste.com/next_batch'
 
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": [{"key": "value"}], "paging": {"next": "%s"}}' % next_url,
                       status=200,
                       content_type='application/json')
@@ -348,7 +348,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
 
         iterations_count = 0
         for item in response().pages(max_pages=0):
-            self.assertIn(item.key().data(), 'value')
+            self.assertIn(item.key().data, 'value')
             iterations_count += 1
 
         self.assertEqual(iterations_count, 0)
@@ -357,7 +357,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
     def test_simple_pages_max_item_zero_iterator(self):
         next_url = 'http://api.teste.com/next_batch'
 
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": [{"key": "value"}], "paging": {"next": "%s"}}' % next_url,
                       status=200,
                       content_type='application/json')
@@ -371,7 +371,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
 
         iterations_count = 0
         for item in response().pages(max_items=0):
-            self.assertIn(item.key().data(), 'value')
+            self.assertIn(item.key().data, 'value')
             iterations_count += 1
 
         self.assertEqual(iterations_count, 0)
@@ -380,7 +380,7 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
     def test_simple_pages_max_item_zero_iterator(self):
         next_url = 'http://api.teste.com/next_batch'
 
-        responses.add(responses.GET, self.wrapper.test().data(),
+        responses.add(responses.GET, self.wrapper.test().data,
                       body='{"data": [{"key": "value"}], "paging": {"next": "%s"}}' % next_url,
                       status=200,
                       content_type='application/json')
@@ -394,14 +394,14 @@ class TestTapiocaExecutorRequests(unittest.TestCase):
 
         iterations_count = 0
         for item in response().pages(max_items=0):
-            self.assertIn(item.key().data(), 'value')
+            self.assertIn(item.key().data, 'value')
             iterations_count += 1
 
     @responses.activate
     def test_data_serialization(self):
         wrapper = SerializerClient()
 
-        responses.add(responses.POST, self.wrapper.test().data(),
+        responses.add(responses.POST, self.wrapper.test().data,
                       body='{}', status=200, content_type='application/json')
 
         string_date = '2014-11-13T14:53:18.694072+00:00'


### PR DESCRIPTION
#77 