### PR TITLE
initial commit with xml and an oauth2 token request helper

### DIFF
--- a/tapioca/adapters.py
+++ b/tapioca/adapters.py
@@ -7,7 +7,7 @@ from .exceptions import (
     ResponseProcessException, ClientError, ServerError)
 from .serializers import SimpleSerializer
 from .xml_helpers import (
-    etree_elt_dict_to_xml,  flat_dict_to_etree_elt_dict, xml_string_to_etree_elt_dict)
+    input_branches_to_xml_bytestring, xml_string_to_etree_elt_dict)
 
 
 def generate_wrapper_from_adapter(adapter_class):
@@ -127,17 +127,11 @@ class XMLAdapterMixin(object):
 
     def format_data_to_request(self, data):
         if data:
-            return etree_elt_dict_to_xml(data)
+            return input_branches_to_xml_bytestring(data)
 
     def response_to_native(self, response):
         if response.content.strip():
             if 'xml' in response.headers['content-type']:
-                return xml_string_to_etree_elt_dict(response.content)
+                return {'xml': response.content,
+                        'dict': xml_string_to_etree_elt_dict(response.content)}
             return {'text': response.text}
-
-
-class FlatXMLAdapterMixin(XMLAdapterMixin):
-
-    def format_data_to_request(self, data):
-        if data:
-            return etree_elt_dict_to_xml(flat_dict_to_etree_elt_dict(data))

--- a/tapioca/adapters.py
+++ b/tapioca/adapters.py
@@ -113,10 +113,10 @@ class JSONAdapterMixin(object):
             return response.json()
 
 
-class XmlAdapterMixin(object):
+class XMLAdapterMixin(object):
 
     def get_request_kwargs(self, api_params, *args, **kwargs):
-        arguments = super(XmlAdapterMixin, self).get_request_kwargs(
+        arguments = super(XMLAdapterMixin, self).get_request_kwargs(
             api_params, *args, **kwargs)
 
         if 'headers' not in arguments:
@@ -136,7 +136,7 @@ class XmlAdapterMixin(object):
             return {'text': response.text}
 
 
-class FlatXmlAdapterMixin(XmlAdapterMixin):
+class FlatXMLAdapterMixin(XMLAdapterMixin):
 
     def format_data_to_request(self, data):
         if data:

--- a/tapioca/oauth2_token_requester.py
+++ b/tapioca/oauth2_token_requester.py
@@ -1,0 +1,50 @@
+from requests_oauthlib import OAuth2Session
+
+
+class Oauth2TokenRequester(object):
+
+    def __init__(self,
+                 client_id,
+                 client_secret,
+                 redirect_uri,
+                 authorization_base_url,
+                 obtain_token_url,
+                 scope_list,
+                 **auth_base_url_kwargs):
+
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+        self.authorization_base_url = authorization_base_url
+        self.obtain_token_url = obtain_token_url
+        self.scope_list = scope_list
+        self.auth_base_url_kwargs = auth_base_url_kwargs
+
+    def request_token(self):
+        '''
+        Uses requests_oauthlib to request a token and response.
+        Requires your app to have a redirect_uri set up.
+
+        Prompts user through steps of obtaining a token.
+
+        Usage:
+        o = OauthRequester(**kwargs)  # '**kwargs' for brevity.
+        token = o.request_token()
+        '''
+        oauth = OAuth2Session(self.client_id,
+                              scope=self.scope_list,
+                              redirect_uri=self.redirect_uri)
+        authorization_url, state = oauth.authorization_url(self.authorization_base_url,
+                                                           **self.auth_base_url_kwargs)
+
+        print ('\n###### OauthRequester User Prompt ######\n'
+               '1. Please go to the following URL to authorize access: \n\n%s' % authorization_url)
+
+        redirect_response = raw_input('\n2. Enter the full callback URL that your request was '
+                                      'redirected to:\n')
+
+        oauth.fetch_token(self.obtain_token_url,
+                          authorization_response=redirect_response,
+                          client_secret=self.client_secret)
+
+        return oauth.token

--- a/tapioca/oauth2_token_requester.py
+++ b/tapioca/oauth2_token_requester.py
@@ -20,31 +20,30 @@ class Oauth2TokenRequester(object):
         self.scope_list = scope_list
         self.auth_base_url_kwargs = auth_base_url_kwargs
 
-    def request_token(self):
+    def authorize_app(self):
         '''
         Uses requests_oauthlib to request a token and response.
         Requires your app to have a redirect_uri set up.
 
-        Prompts user through steps of obtaining a token.
-
         Usage:
-        o = OauthRequester(**kwargs)  # '**kwargs' for brevity.
-        token = o.request_token()
+        o = Oauth2TokenRequester(**kwargs)  # '**kwargs' for brevity.
+        authorization_url = o.authorize_app()
+        # go to authorization_url to perform authorization with third party
+        # record redirect_response
+        token = o.get_token(redirect_response)
         '''
-        oauth = OAuth2Session(self.client_id,
-                              scope=self.scope_list,
-                              redirect_uri=self.redirect_uri)
-        authorization_url, state = oauth.authorization_url(self.authorization_base_url,
-                                                           **self.auth_base_url_kwargs)
+        self.oauth = OAuth2Session(self.client_id,
+                                   scope=self.scope_list,
+                                   redirect_uri=self.redirect_uri)
+        authorization_url, state = self.oauth.authorization_url(self.authorization_base_url,
+                                                                **self.auth_base_url_kwargs)
 
-        print ('\n###### OauthRequester User Prompt ######\n'
-               '1. Please go to the following URL to authorize access: \n\n%s' % authorization_url)
+        return authorization_url
 
-        redirect_response = raw_input('\n2. Enter the full callback URL that your request was '
-                                      'redirected to:\n')
+    def get_token(self, redirect_response):
 
-        oauth.fetch_token(self.obtain_token_url,
-                          authorization_response=redirect_response,
-                          client_secret=self.client_secret)
+        self.oauth.fetch_token(self.obtain_token_url,
+                               authorization_response=redirect_response,
+                               client_secret=self.client_secret)
 
-        return oauth.token
+        return self.oauth.token

--- a/tapioca/xml_helpers.py
+++ b/tapioca/xml_helpers.py
@@ -74,9 +74,7 @@ def etree_elt_dict_to_xml(etree_elt_dict):
     '''
     if not isinstance(etree_elt_dict, Mapping):
         raise Exception('Structure must be a Mapping object')
-    return bytes(
-        ElementTree.tostring(_etree_elt_list_to_xml([etree_elt_dict])[0])
-    )
+    return ElementTree.tostring(_etree_elt_list_to_xml([etree_elt_dict])[0], encoding='utf-8')
 
 
 def _etree_node_to_etree_elt_dict(etree_node):
@@ -102,13 +100,13 @@ def xml_string_to_etree_elt_dict(xml_string):
 
 def input_branches_to_xml_bytestring(data):
     if type(data) == ElementTree.Element:
-        return bytes(ElementTree.tostring(data))
+        return ElementTree.tostring(data, encoding='utf-8')
     elif type(data) in (str, bytes):
-        return bytes(data)
+        return data.encode('utf-8')
     elif type(data) == dict:
         if 'tag' in data.keys():
-            return bytes(etree_elt_dict_to_xml(data))
+            return etree_elt_dict_to_xml(data)
         else:
-            return bytes(etree_elt_dict_to_xml(flat_dict_to_etree_elt_dict(data)))
+            return etree_elt_dict_to_xml(flat_dict_to_etree_elt_dict(data))
     else:
         raise Exception('Format not recognized')

--- a/tapioca/xml_helpers.py
+++ b/tapioca/xml_helpers.py
@@ -1,0 +1,96 @@
+from xml.etree import ElementTree
+from collections import Mapping
+from operator import methodcaller
+
+
+def flat_dict_to_etree_elt_dict(dict_to_convert, _depth=0):
+    '''
+    Convert a special flat format to a dictionary that can be readily mapped to etree.Element.
+
+    The special flat format is intended to be similar to XML arguments and easy to type while
+    reading XML related API documents.
+
+    This format does not allow for combinations of text, subelements, and tails. It supports
+    either text or subelements. If you need more flexibility, use the more general etree_elt_dict
+    format with the etree_elt_dict_to_xml() method.
+
+    A single root node is required.
+    Double quotes in attribute values are stripped and optional.
+
+    Example Input:
+    {'root|attr1="val 1"': {'subroot1|attr1="sub val 1"': 'sub text 1',
+                            'subroot2|attr2="sub val 2"': 'sub text 2'}}
+    '''
+    if not _depth and len(dict_to_convert) > 1:
+        raise Exception('Multiple root nodes detected, please check input has only one root node.')
+    node_list = []
+    for k, v in dict_to_convert.items():
+        etree_elt_dict = {}
+        etree_elt_dict['tag'], attrib_list = [k.split('|')[0], k.split('|')[1:]]
+        etree_elt_dict['attrib'] = {k: v.replace('"', '') for k, v
+                                    in map(methodcaller('split', '='), attrib_list)}
+
+        # no support for text and subelements for any single node.
+        if isinstance(v, Mapping):
+            etree_elt_dict['text'] = ''
+            etree_elt_dict['sub_elts'] = flat_dict_to_etree_elt_dict(dict_to_convert=v,
+                                                                     _depth=_depth + 1)
+        elif isinstance(v, str):
+            etree_elt_dict['text'] = v
+            etree_elt_dict['sub_elts'] = ''
+        else:
+            raise Exception('Child element not of type Mapping or String')
+
+        etree_elt_dict['tail'] = ''
+        node_list.append(etree_elt_dict)
+    return node_list if _depth else node_list[0]
+
+
+def _etree_elt_list_to_xml(etree_elt_list):
+    '''
+    Helper method to handle lists of etree_elt_dicts.
+    '''
+    return_list = []
+    # todo: test for required keys
+    for etree_elt_dict in etree_elt_list:
+        if not isinstance(etree_elt_dict, Mapping):
+            raise Exception('Structure must be a Mapping object')
+        node = ElementTree.Element(etree_elt_dict['tag'],
+                                   attrib=etree_elt_dict['attrib'])
+        node.text = etree_elt_dict['text']
+        node.tail = etree_elt_dict['tail']
+        if etree_elt_dict['sub_elts']:
+            node.extend(_etree_elt_list_to_xml(etree_elt_dict['sub_elts']))
+        return_list.append(node)
+    return return_list
+
+
+def etree_elt_dict_to_xml(etree_elt_dict):
+    '''
+    Converts an etree_elt_dict into XML. There must be a single root node.
+    An etree_elt_dict is designed to readily map onto ElementTree.Element.
+    '''
+    if not isinstance(etree_elt_dict, Mapping):
+        raise Exception('Structure must be a Mapping object')
+    return bytes(
+        ElementTree.tostring(_etree_elt_list_to_xml([etree_elt_dict])[0])
+    )
+
+
+def etree_node_to_etree_elt_dict(etree_node):
+    etree_elt_dict = {}
+    etree_elt_dict['tag'] = etree_node.tag
+    etree_elt_dict['attrib'] = etree_node.attrib
+    etree_elt_dict['text'] = etree_node.text
+    etree_elt_dict['tail'] = etree_node.tail
+
+    sub_elts = []
+    for child_node in etree_node:
+        sub_elts.append(etree_node_to_etree_elt_dict(child_node))
+    etree_elt_dict['sub_elts'] = sub_elts
+
+    return etree_elt_dict
+
+
+def xml_string_to_etree_elt_dict(xml_string):
+    return etree_node_to_etree_elt_dict(ElementTree.fromstring(xml_string))

--- a/tapioca/xml_helpers.py
+++ b/tapioca/xml_helpers.py
@@ -79,14 +79,15 @@ def etree_elt_dict_to_xml(etree_elt_dict):
     )
 
 
-def etree_node_to_etree_elt_dict(etree_node):
+def _etree_node_to_etree_elt_dict(etree_node):
+    # for output
     etree_elt_dict = {}
     etree_elt_dict['tag'] = etree_node.tag
     etree_elt_dict['attrib'] = etree_node.attrib
     etree_elt_dict['text'] = etree_node.text
     etree_elt_dict['tail'] = etree_node.tail
 
-    sub_elts = [etree_node_to_etree_elt_dict(n) for n in etree_node]
+    sub_elts = [_etree_node_to_etree_elt_dict(n) for n in etree_node]
     if sub_elts:
         etree_elt_dict['sub_elts'] = sub_elts
     else:
@@ -95,4 +96,19 @@ def etree_node_to_etree_elt_dict(etree_node):
 
 
 def xml_string_to_etree_elt_dict(xml_string):
-    return etree_node_to_etree_elt_dict(ElementTree.fromstring(xml_string))
+    # for output
+    return _etree_node_to_etree_elt_dict(ElementTree.fromstring(xml_string))
+
+
+def input_branches_to_xml_bytestring(data):
+    if type(data) == ElementTree.Element:
+        return bytes(ElementTree.tostring(data))
+    elif type(data) in (str, bytes):
+        return bytes(data)
+    elif type(data) == dict:
+        if 'tag' in data.keys():
+            return bytes(etree_elt_dict_to_xml(data))
+        else:
+            return bytes(etree_elt_dict_to_xml(flat_dict_to_etree_elt_dict(data)))
+    else:
+        raise Exception('Format not recognized')

--- a/tapioca/xml_helpers.py
+++ b/tapioca/xml_helpers.py
@@ -32,17 +32,19 @@ def flat_dict_to_etree_elt_dict(dict_to_convert, _depth=0):
 
         # no support for text and subelements for any single node.
         if isinstance(v, Mapping):
-            etree_elt_dict['text'] = ''
+            etree_elt_dict['text'] = None
             etree_elt_dict['sub_elts'] = flat_dict_to_etree_elt_dict(dict_to_convert=v,
                                                                      _depth=_depth + 1)
         elif isinstance(v, str):
             etree_elt_dict['text'] = v
-            etree_elt_dict['sub_elts'] = ''
+            etree_elt_dict['sub_elts'] = None
         else:
             raise Exception('Child element not of type Mapping or String')
 
-        etree_elt_dict['tail'] = ''
+        etree_elt_dict['tail'] = None
         node_list.append(etree_elt_dict)
+    if not node_list:
+        node_list = None
     return node_list if _depth else node_list[0]
 
 
@@ -84,11 +86,11 @@ def etree_node_to_etree_elt_dict(etree_node):
     etree_elt_dict['text'] = etree_node.text
     etree_elt_dict['tail'] = etree_node.tail
 
-    sub_elts = []
-    for child_node in etree_node:
-        sub_elts.append(etree_node_to_etree_elt_dict(child_node))
-    etree_elt_dict['sub_elts'] = sub_elts
-
+    sub_elts = [etree_node_to_etree_elt_dict(n) for n in etree_node]
+    if sub_elts:
+        etree_elt_dict['sub_elts'] = sub_elts
+    else:
+        etree_elt_dict['sub_elts'] = None
     return etree_elt_dict
 
 

--- a/tapioca/xml_helpers.py
+++ b/tapioca/xml_helpers.py
@@ -101,8 +101,10 @@ def xml_string_to_etree_elt_dict(xml_string):
 def input_branches_to_xml_bytestring(data):
     if type(data) == ElementTree.Element:
         return ElementTree.tostring(data, encoding='utf-8')
-    elif type(data) in (str, bytes):
+    elif type(data) == str:
         return data.encode('utf-8')
+    elif type(data) == bytes:
+        return data
     elif type(data) == dict:
         if 'tag' in data.keys():
             return etree_elt_dict_to_xml(data)

--- a/tests/test_xml_helpers.py
+++ b/tests/test_xml_helpers.py
@@ -1,0 +1,214 @@
+# coding: utf-8
+
+import unittest
+
+from tapioca.xml_helpers import flat_dict_to_etree_elt_dict
+from tapioca.xml_helpers import etree_elt_dict_to_xml
+
+
+# Use sets of 3 to test the translation methods
+# Note: There are limitations to the 'flat' format when compared to ElementTree.Element, so these
+# tests don't yet cover the full range of inputs to etree_elt_dict_to_xml()
+FLAT_1 = {'root1|attr1="my attr value 1"|attr2="my attr value 2"': 'root text'}
+ETREE_DICT_1 = {'tag': 'root1',
+                       'attrib': {'attr1': 'my attr value 1',
+                                  'attr2': 'my attr value 2'},
+                       'text': 'root text',
+                       'tail': '',
+                       'sub_elts': ''}
+XML_STR_1 = b'<root1 attr1="my attr value 1" attr2="my attr value 2">root text</root1>'
+
+FLAT_2 = {'root2|attr1="my attr value 1"': {
+          'subroot1|subattr1="sub attr value 1"': 'subtext 1'}}
+ETREE_DICT_2 = {'tag': 'root2',
+                'attrib': {'attr1': 'my attr value 1'},
+                'text': '',
+                'tail': '',
+                'sub_elts': [{'tag': 'subroot1',
+                              'attrib': {'subattr1': 'sub attr value 1'},
+                              'text': 'subtext 1',
+                              'tail': '',
+                              'sub_elts': ''}]
+                }
+XML_STR_2 = (b'<root2 attr1="my attr value 1"><subroot1 subattr1="sub attr value 1">'
+             b'subtext 1</subroot1></root2>')
+
+FLAT_3 = {'root2|attr1="my attr value 1"': {
+          'subroot1|subattr1="sub attr value 1"': {
+              'subroot2|subattr2="sub attr value 2"': 'subtext 2'}
+          }}
+ETREE_DICT_3 = {'tag': 'root2',
+                'attrib': {'attr1': 'my attr value 1'},
+                'text': '',
+                'tail': '',
+                'sub_elts': [{'tag': 'subroot1',
+                              'attrib': {'subattr1': 'sub attr value 1'},
+                              'text': '',
+                              'tail': '',
+                              'sub_elts': [{'tag': 'subroot2',
+                                            'attrib': {'subattr2': 'sub attr value 2'},
+                                            'text': 'subtext 2',
+                                            'tail': '',
+                                            'sub_elts': ''}]
+                              }]
+                }
+XML_STR_3 = (b'<root2 attr1="my attr value 1">'
+             b'<subroot1 subattr1="sub attr value 1">'
+             b'<subroot2 subattr2="sub attr value 2">'
+             b'subtext 2'
+             b'</subroot2></subroot1></root2>')
+FLAT_MULT = {'root1|attr1="my attr value 1"|attr2="my attr value 2"': 'root text',
+             'root2|attr1="my attr value 1"':
+                 {'subroot1|subattr1="sub attr value 1"': 'subtext 1'}
+             }
+ETREE_DICT_MULT = [{'tag': 'root2',
+                    'attrib': {'attr1': 'my attr value 1'},
+                    'text': '',
+                    'tail': '',
+                    'sub_elts': [{'tag': 'subroot1',
+                                  'attrib': {'subattr1': 'sub attr value 1'},
+                                  'text': 'subtext 1',
+                                  'tail': '',
+                                  'sub_elts': ''}]
+                    },
+                   {'tag': 'root1',
+                    'attrib': {'attr1': 'my attr value 1',
+                               'attr2': 'my attr value 2'},
+                    'text': 'root text',
+                    'tail': '',
+                    'sub_elts': ''}]
+
+FLAT_MULT_SUB = {'root|attr1="val 1"': {'subroot1|attr1="sub val 1"': 'sub text 1',
+                                        'subroot2|attr2="sub val 2"': 'sub text 2'}}
+
+ETREE_DICT_MULT_SUB = {'tag': 'root',
+                       'attrib': {'attr1': 'val 1'},
+                       'text': '',
+                       'tail': '',
+                       'sub_elts': [{'tag': 'subroot1',
+                                     'attrib': {'attr1': 'sub val 1'},
+                                     'text': 'sub text 1',
+                                     'tail': '',
+                                     'sub_elts': ''},
+                                    {'tag': 'subroot2',
+                                     'attrib': {'attr2': 'sub val 2'},
+                                     'text': 'sub text 2',
+                                     'tail': '',
+                                     'sub_elts': ''}]
+                       }
+XML_STR_MULT_SUB = (b'<root attr1="val 1">'
+                    b'<subroot1 attr1="sub val 1">sub text 1</subroot1>'
+                    b'<subroot2 attr2="sub val 2">sub text 2</subroot2>'
+                    b'</root>')
+
+
+class TestFlatToEtree(unittest.TestCase):
+
+    def test_raises_exception_when_input_is_wrong(self):
+        d = {'abc'}
+
+        self.assertRaises(Exception, flat_dict_to_etree_elt_dict, d)
+
+    def test_raises_exception_when_child_type_is_wrong(self):
+        d = {'root2|attr1="my attr value 1"': [
+            'subroot1|subattr1="sub attr value 1"', 'subtext 1'
+            ]
+        }
+
+        self.assertRaises(Exception, flat_dict_to_etree_elt_dict, d)
+
+    def test_one_level(self):
+        d = FLAT_1
+        expected_out = ETREE_DICT_1
+
+        out = flat_dict_to_etree_elt_dict(d)
+
+        self.assertEqual(out, expected_out)
+
+    def test_two_levels(self):
+        d = FLAT_2
+        expected_out = ETREE_DICT_2
+
+        out = flat_dict_to_etree_elt_dict(d)
+
+        self.assertEqual(out, expected_out)
+
+    def test_three_levels(self):
+        d = FLAT_3
+        expected_out = ETREE_DICT_3
+
+        out = flat_dict_to_etree_elt_dict(d)
+
+        self.assertEqual(out, expected_out)
+
+    def test_multiple_root_nodes_raises_exception(self):
+        d = FLAT_MULT
+
+        self.assertRaises(Exception, etree_elt_dict_to_xml, d)
+
+    def test_multiple_sub_nodes(self):
+        d = FLAT_MULT_SUB
+        expected_out = ETREE_DICT_MULT_SUB
+
+        out = flat_dict_to_etree_elt_dict(d)
+
+        for key in out.keys():
+            if key != 'sub_elts':
+                self.assertEqual(out[key], expected_out[key])
+        for d in out['sub_elts']:
+            self.assertIn(d, expected_out['sub_elts'])
+
+
+class TestEtreeEltDictToXml(unittest.TestCase):
+
+    def test_raises_exception_when_input_is_wrong(self):
+        d = ['abc']
+
+        self.assertRaises(Exception, etree_elt_dict_to_xml, d)
+
+    def test_one_level(self):
+        d = ETREE_DICT_1
+        expected_out = XML_STR_1
+
+        out = etree_elt_dict_to_xml(d)
+
+        self.assertEqual(out, expected_out)
+
+    def test_two_levels(self):
+        d = ETREE_DICT_2
+        expected_out = XML_STR_2
+
+        out = etree_elt_dict_to_xml(d)
+
+        self.assertEqual(out, expected_out)
+
+    def test_three_levels(self):
+        d = ETREE_DICT_3
+        expected_out = XML_STR_3
+
+        out = etree_elt_dict_to_xml(d)
+
+        self.assertEqual(out, expected_out)
+
+    def test_multiple_root_nodes_raises_exception(self):
+        d = ETREE_DICT_MULT
+
+        self.assertRaises(Exception, etree_elt_dict_to_xml, d)
+
+    def test_multiple_sub_nodes(self):
+        d = ETREE_DICT_MULT_SUB
+        expected_out = XML_STR_MULT_SUB
+
+        out = etree_elt_dict_to_xml(d)
+
+        self.assertEqual(out, expected_out)  # potential sequencing issue
+
+
+class TestEtreeNodeToEltDict(unittest.TestCase):
+
+    def test_etree_node_to_etree_elt_dict(self):
+        pass
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_xml_helpers.py
+++ b/tests/test_xml_helpers.py
@@ -2,8 +2,8 @@
 
 import unittest
 
-from tapioca.xml_helpers import flat_dict_to_etree_elt_dict
-from tapioca.xml_helpers import etree_elt_dict_to_xml
+from tapioca.xml_helpers import (
+    etree_elt_dict_to_xml, flat_dict_to_etree_elt_dict, xml_string_to_etree_elt_dict)
 
 
 # Use sets of 3 to test the translation methods
@@ -14,21 +14,21 @@ ETREE_DICT_1 = {'tag': 'root1',
                        'attrib': {'attr1': 'my attr value 1',
                                   'attr2': 'my attr value 2'},
                        'text': 'root text',
-                       'tail': '',
-                       'sub_elts': ''}
+                       'tail': None,
+                       'sub_elts': None}
 XML_STR_1 = b'<root1 attr1="my attr value 1" attr2="my attr value 2">root text</root1>'
 
 FLAT_2 = {'root2|attr1="my attr value 1"': {
           'subroot1|subattr1="sub attr value 1"': 'subtext 1'}}
 ETREE_DICT_2 = {'tag': 'root2',
                 'attrib': {'attr1': 'my attr value 1'},
-                'text': '',
-                'tail': '',
+                'text': None,
+                'tail': None,
                 'sub_elts': [{'tag': 'subroot1',
                               'attrib': {'subattr1': 'sub attr value 1'},
                               'text': 'subtext 1',
-                              'tail': '',
-                              'sub_elts': ''}]
+                              'tail': None,
+                              'sub_elts': None}]
                 }
 XML_STR_2 = (b'<root2 attr1="my attr value 1"><subroot1 subattr1="sub attr value 1">'
              b'subtext 1</subroot1></root2>')
@@ -39,17 +39,17 @@ FLAT_3 = {'root2|attr1="my attr value 1"': {
           }}
 ETREE_DICT_3 = {'tag': 'root2',
                 'attrib': {'attr1': 'my attr value 1'},
-                'text': '',
-                'tail': '',
+                'text': None,
+                'tail': None,
                 'sub_elts': [{'tag': 'subroot1',
                               'attrib': {'subattr1': 'sub attr value 1'},
-                              'text': '',
-                              'tail': '',
+                              'text': None,
+                              'tail': None,
                               'sub_elts': [{'tag': 'subroot2',
                                             'attrib': {'subattr2': 'sub attr value 2'},
                                             'text': 'subtext 2',
-                                            'tail': '',
-                                            'sub_elts': ''}]
+                                            'tail': None,
+                                            'sub_elts': None}]
                               }]
                 }
 XML_STR_3 = (b'<root2 attr1="my attr value 1">'
@@ -63,38 +63,38 @@ FLAT_MULT = {'root1|attr1="my attr value 1"|attr2="my attr value 2"': 'root text
              }
 ETREE_DICT_MULT = [{'tag': 'root2',
                     'attrib': {'attr1': 'my attr value 1'},
-                    'text': '',
-                    'tail': '',
+                    'text': None,
+                    'tail': None,
                     'sub_elts': [{'tag': 'subroot1',
                                   'attrib': {'subattr1': 'sub attr value 1'},
                                   'text': 'subtext 1',
-                                  'tail': '',
-                                  'sub_elts': ''}]
+                                  'tail': None,
+                                  'sub_elts': None}]
                     },
                    {'tag': 'root1',
                     'attrib': {'attr1': 'my attr value 1',
                                'attr2': 'my attr value 2'},
                     'text': 'root text',
-                    'tail': '',
-                    'sub_elts': ''}]
+                    'tail': None,
+                    'sub_elts': None}]
 
 FLAT_MULT_SUB = {'root|attr1="val 1"': {'subroot1|attr1="sub val 1"': 'sub text 1',
                                         'subroot2|attr2="sub val 2"': 'sub text 2'}}
 
 ETREE_DICT_MULT_SUB = {'tag': 'root',
                        'attrib': {'attr1': 'val 1'},
-                       'text': '',
-                       'tail': '',
+                       'text': None,
+                       'tail': None,
                        'sub_elts': [{'tag': 'subroot1',
                                      'attrib': {'attr1': 'sub val 1'},
                                      'text': 'sub text 1',
-                                     'tail': '',
-                                     'sub_elts': ''},
+                                     'tail': None,
+                                     'sub_elts': None},
                                     {'tag': 'subroot2',
                                      'attrib': {'attr2': 'sub val 2'},
                                      'text': 'sub text 2',
-                                     'tail': '',
-                                     'sub_elts': ''}]
+                                     'tail': None,
+                                     'sub_elts': None}]
                        }
 XML_STR_MULT_SUB = (b'<root attr1="val 1">'
                     b'<subroot1 attr1="sub val 1">sub text 1</subroot1>'
@@ -204,11 +204,19 @@ class TestEtreeEltDictToXml(unittest.TestCase):
         self.assertEqual(out, expected_out)  # potential sequencing issue
 
 
-class TestEtreeNodeToEltDict(unittest.TestCase):
+class TestXmlStringToEtreeEltDict(unittest.TestCase):
 
-    def test_etree_node_to_etree_elt_dict(self):
-        pass
+    def test_xml_string_to_etree_elt_dict(self):
+        xml = XML_STR_MULT_SUB
+        expected_out = ETREE_DICT_MULT_SUB
 
+        out = xml_string_to_etree_elt_dict(xml)
+
+        for key in out.keys():
+            if key != 'sub_elts':
+                self.assertEqual(out[key], expected_out[key])
+        for d in out['sub_elts']:
+            self.assertIn(d, expected_out['sub_elts'])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_xml_helpers.py
+++ b/tests/test_xml_helpers.py
@@ -1,9 +1,11 @@
 # coding: utf-8
 
 import unittest
-
+from collections import OrderedDict
+from xml.etree import ElementTree
 from tapioca.xml_helpers import (
-    etree_elt_dict_to_xml, flat_dict_to_etree_elt_dict, xml_string_to_etree_elt_dict)
+    etree_elt_dict_to_xml, flat_dict_to_etree_elt_dict, xml_string_to_etree_elt_dict,
+    input_branches_to_xml_bytestring)
 
 
 # Use sets of 3 to test the translation methods
@@ -78,8 +80,8 @@ ETREE_DICT_MULT = [{'tag': 'root2',
                     'tail': None,
                     'sub_elts': None}]
 
-FLAT_MULT_SUB = {'root|attr1="val 1"': {'subroot1|attr1="sub val 1"': 'sub text 1',
-                                        'subroot2|attr2="sub val 2"': 'sub text 2'}}
+FLAT_MULT_SUB = {'root|attr1="val 1"': OrderedDict([('subroot1|attr1="sub val 1"', 'sub text 1'),
+                                                    ('subroot2|attr2="sub val 2"', 'sub text 2')])}
 
 ETREE_DICT_MULT_SUB = {'tag': 'root',
                        'attrib': {'attr1': 'val 1'},
@@ -155,11 +157,11 @@ class TestFlatToEtree(unittest.TestCase):
         for key in out.keys():
             if key != 'sub_elts':
                 self.assertEqual(out[key], expected_out[key])
-        for d in out['sub_elts']:
-            self.assertIn(d, expected_out['sub_elts'])
+        self.assertEqual(out['sub_elts'][0], expected_out['sub_elts'][0])
+        self.assertEqual(out['sub_elts'][1], expected_out['sub_elts'][1])
 
 
-class TestEtreeEltDictToXml(unittest.TestCase):
+class TestEtreeEltDictToXML(unittest.TestCase):
 
     def test_raises_exception_when_input_is_wrong(self):
         d = ['abc']
@@ -201,10 +203,50 @@ class TestEtreeEltDictToXml(unittest.TestCase):
 
         out = etree_elt_dict_to_xml(d)
 
-        self.assertEqual(out, expected_out)  # potential sequencing issue
+        self.assertEqual(out, expected_out)
 
 
-class TestXmlStringToEtreeEltDict(unittest.TestCase):
+class TestXMLInputBranches(unittest.TestCase):
+
+    def test_branch_etree_element(self):
+        elt = ElementTree.fromstring(XML_STR_MULT_SUB)
+        expected_out = XML_STR_MULT_SUB
+
+        out = input_branches_to_xml_bytestring(elt)
+
+        self.assertEqual(out, expected_out)
+
+    def test_branch_xml_string(self):
+        xml = XML_STR_MULT_SUB
+        expected_out = XML_STR_MULT_SUB
+
+        out = input_branches_to_xml_bytestring(xml)
+
+        self.assertEqual(out, expected_out)
+
+    def test_branch_etree_elt_dict(self):
+        d = ETREE_DICT_MULT_SUB
+        expected_out = XML_STR_MULT_SUB
+
+        out = input_branches_to_xml_bytestring(d)
+
+        self.assertEqual(out, expected_out)
+
+    def test_branch_flat_dict(self):
+        d = FLAT_MULT_SUB
+        expected_out = XML_STR_MULT_SUB
+
+        out = input_branches_to_xml_bytestring(d)
+
+        self.assertEqual(out, expected_out)
+
+    def test_raises_exception_if_wrong_input(self):
+        d = ['abc']
+
+        self.assertRaises(Exception, input_branches_to_xml_bytestring, d)
+
+
+class TestXMLStringToEtreeEltDict(unittest.TestCase):
 
     def test_xml_string_to_etree_elt_dict(self):
         xml = XML_STR_MULT_SUB
@@ -215,8 +257,8 @@ class TestXmlStringToEtreeEltDict(unittest.TestCase):
         for key in out.keys():
             if key != 'sub_elts':
                 self.assertEqual(out[key], expected_out[key])
-        for d in out['sub_elts']:
-            self.assertIn(d, expected_out['sub_elts'])
+        self.assertEqual(out['sub_elts'][0], expected_out['sub_elts'][0])
+        self.assertEqual(out['sub_elts'][1], expected_out['sub_elts'][1])
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_xml_helpers.py
+++ b/tests/test_xml_helpers.py
@@ -224,6 +224,14 @@ class TestXMLInputBranches(unittest.TestCase):
 
         self.assertEqual(out, expected_out)
 
+    def test_branch_xml_bytes(self):
+        xml = XML_STR_MULT_SUB.encode('utf-8')
+        expected_out = XML_STR_MULT_SUB.encode('utf-8')
+
+        out = input_branches_to_xml_bytestring(xml)
+
+        self.assertEqual(out, expected_out)
+
     def test_branch_etree_elt_dict(self):
         d = ETREE_DICT_MULT_SUB
         expected_out = XML_STR_MULT_SUB.encode('utf-8')

--- a/tests/test_xml_helpers.py
+++ b/tests/test_xml_helpers.py
@@ -18,7 +18,7 @@ ETREE_DICT_1 = {'tag': 'root1',
                        'text': 'root text',
                        'tail': None,
                        'sub_elts': None}
-XML_STR_1 = b'<root1 attr1="my attr value 1" attr2="my attr value 2">root text</root1>'
+XML_STR_1 = '<root1 attr1="my attr value 1" attr2="my attr value 2">root text</root1>'
 
 FLAT_2 = {'root2|attr1="my attr value 1"': {
           'subroot1|subattr1="sub attr value 1"': 'subtext 1'}}
@@ -32,8 +32,8 @@ ETREE_DICT_2 = {'tag': 'root2',
                               'tail': None,
                               'sub_elts': None}]
                 }
-XML_STR_2 = (b'<root2 attr1="my attr value 1"><subroot1 subattr1="sub attr value 1">'
-             b'subtext 1</subroot1></root2>')
+XML_STR_2 = ('<root2 attr1="my attr value 1"><subroot1 subattr1="sub attr value 1">'
+             'subtext 1</subroot1></root2>')
 
 FLAT_3 = {'root2|attr1="my attr value 1"': {
           'subroot1|subattr1="sub attr value 1"': {
@@ -54,11 +54,11 @@ ETREE_DICT_3 = {'tag': 'root2',
                                             'sub_elts': None}]
                               }]
                 }
-XML_STR_3 = (b'<root2 attr1="my attr value 1">'
-             b'<subroot1 subattr1="sub attr value 1">'
-             b'<subroot2 subattr2="sub attr value 2">'
-             b'subtext 2'
-             b'</subroot2></subroot1></root2>')
+XML_STR_3 = ('<root2 attr1="my attr value 1">'
+             '<subroot1 subattr1="sub attr value 1">'
+             '<subroot2 subattr2="sub attr value 2">'
+             'subtext 2'
+             '</subroot2></subroot1></root2>')
 FLAT_MULT = {'root1|attr1="my attr value 1"|attr2="my attr value 2"': 'root text',
              'root2|attr1="my attr value 1"':
                  {'subroot1|subattr1="sub attr value 1"': 'subtext 1'}
@@ -98,10 +98,10 @@ ETREE_DICT_MULT_SUB = {'tag': 'root',
                                      'tail': None,
                                      'sub_elts': None}]
                        }
-XML_STR_MULT_SUB = (b'<root attr1="val 1">'
-                    b'<subroot1 attr1="sub val 1">sub text 1</subroot1>'
-                    b'<subroot2 attr2="sub val 2">sub text 2</subroot2>'
-                    b'</root>')
+XML_STR_MULT_SUB = ('<root attr1="val 1">'
+                    '<subroot1 attr1="sub val 1">sub text 1</subroot1>'
+                    '<subroot2 attr2="sub val 2">sub text 2</subroot2>'
+                    '</root>')
 
 
 class TestFlatToEtree(unittest.TestCase):
@@ -170,7 +170,7 @@ class TestEtreeEltDictToXML(unittest.TestCase):
 
     def test_one_level(self):
         d = ETREE_DICT_1
-        expected_out = XML_STR_1
+        expected_out = XML_STR_1.encode('utf-8')
 
         out = etree_elt_dict_to_xml(d)
 
@@ -178,7 +178,7 @@ class TestEtreeEltDictToXML(unittest.TestCase):
 
     def test_two_levels(self):
         d = ETREE_DICT_2
-        expected_out = XML_STR_2
+        expected_out = XML_STR_2.encode('utf-8')
 
         out = etree_elt_dict_to_xml(d)
 
@@ -186,7 +186,7 @@ class TestEtreeEltDictToXML(unittest.TestCase):
 
     def test_three_levels(self):
         d = ETREE_DICT_3
-        expected_out = XML_STR_3
+        expected_out = XML_STR_3.encode('utf-8')
 
         out = etree_elt_dict_to_xml(d)
 
@@ -199,7 +199,7 @@ class TestEtreeEltDictToXML(unittest.TestCase):
 
     def test_multiple_sub_nodes(self):
         d = ETREE_DICT_MULT_SUB
-        expected_out = XML_STR_MULT_SUB
+        expected_out = XML_STR_MULT_SUB.encode('utf-8')
 
         out = etree_elt_dict_to_xml(d)
 
@@ -210,7 +210,7 @@ class TestXMLInputBranches(unittest.TestCase):
 
     def test_branch_etree_element(self):
         elt = ElementTree.fromstring(XML_STR_MULT_SUB)
-        expected_out = XML_STR_MULT_SUB
+        expected_out = XML_STR_MULT_SUB.encode('utf-8')
 
         out = input_branches_to_xml_bytestring(elt)
 
@@ -218,7 +218,7 @@ class TestXMLInputBranches(unittest.TestCase):
 
     def test_branch_xml_string(self):
         xml = XML_STR_MULT_SUB
-        expected_out = XML_STR_MULT_SUB
+        expected_out = XML_STR_MULT_SUB.encode('utf-8')
 
         out = input_branches_to_xml_bytestring(xml)
 
@@ -226,7 +226,7 @@ class TestXMLInputBranches(unittest.TestCase):
 
     def test_branch_etree_elt_dict(self):
         d = ETREE_DICT_MULT_SUB
-        expected_out = XML_STR_MULT_SUB
+        expected_out = XML_STR_MULT_SUB.encode('utf-8')
 
         out = input_branches_to_xml_bytestring(d)
 
@@ -234,7 +234,7 @@ class TestXMLInputBranches(unittest.TestCase):
 
     def test_branch_flat_dict(self):
         d = FLAT_MULT_SUB
-        expected_out = XML_STR_MULT_SUB
+        expected_out = XML_STR_MULT_SUB.encode('utf-8')
 
         out = input_branches_to_xml_bytestring(d)
 


### PR DESCRIPTION
Hi Filipe (and Vinta Software),

I enjoyed your talk on Wednesday in NYC. I decided to use Tapioca to write a wrapper for the Google Sheets API. In the process, I implemented approaches to issues #78 and #12 (XML and Get Auth Token for Oauth2).

Please review and let me know if this is close to what you had in mind!

Here are some notes on the implementations:

**Addition 1, XML:**
**1.** Added an `XMLAdapterMixin`. I had a little bit of trouble with the `response_to_native()` method in combination with `etree.ElementTree` when the API endpoint was returning errors, my solution was to search for 'xml' in the content-type header and return a different response if it wasn't present.

**2.** I created a custom dictionary format that can be translated into XML so that it's easy for a developer to type when they're exploring an API. For me, typing out an XML string is pretty bad, and typing out a highly nested dictionary representation of XML can be horrible. The format uses pipes to separate node tags from attributes in the dictionary's keys, and the dictionary's values become the text in-between the XML tags.

**How it works:**Translation to XML is handled in two stages. We use the ~~horrible~~ nested dictionary in-between that maps directly onto the [`etree.ElementTree.Element`](https://docs.python.org/2/library/xml.etree.elementtree.html#elementtree-element-objects) object.

The "flat dictionary" format:
```
{'root|attr1="val 1"': {'subroot1|attr1="sub val 1"': 'sub text 1',
                        'subroot2|attr2="sub val 2"': 'sub text 2'}}
```
Is translated into the "etree element dictionary" format:
```
 'attrib': {'attr1': 'val 1'},
 'tag': 'root',
 'tail': None,
 'sub_elts': [
     {'text': 'sub text 1',
      'attrib': {'attr1': 'sub val 1'},
      'tag': 'subroot1',
      'tail': None,
      'sub_elts': None},
     {'text': 'sub text 2',
      'attrib': {'attr2': 'sub val 2'},
      'tag': 'subroot2',
      'tail': None,
      'sub_elts': None}
 ]
}
```
And is finally translated to the following XML bytes string to be handled by Tapioca:
```
'<root attr1="val 1">
    <subroot1 attr1="sub val 1">
        sub text 1
    </subroot1>
    <subroot2 attr2="sub val 2">
        sub text 2
    </subroot2>
</root>'
```

As of now, the response format is returned only in the nested-dictionary format. I think the biggest challenge with handling XML via dictionaries in Tapioca is that developers may want to work directly with XML as either input or output (in addition to the other formats), which is not directly supported. Need to think about how to add those capabilities / amend the existing config requirements without making configuration or branching on input overly confusing or error-prone.

**Edit:** The latest commit f782f1f attempts to address multiple input and output formats through a single interface. The input is branched based on 4 types of input (etree.Element, string representing XML, nested dictionary, and flat dictionary).

Branching code:
```
def input_branches_to_xml_bytestring(data):
    if type(data) == ElementTree.Element:
        return ElementTree.tostring(data, encoding='utf-8')
    elif type(data) == str:
        return data.encode('utf-8')
    elif type(data) == bytes:
        return data
    elif type(data) == dict:
        if 'tag' in data.keys():
            return etree_elt_dict_to_xml(data)
        else:
            return etree_elt_dict_to_xml(flat_dict_to_etree_elt_dict(data))
    else:
        raise Exception('Format not recognized')
```

**Addition 2, Token Request:**
Here, I followed the [Requests-OAuthlib tutorial](http://requests-oauthlib.readthedocs.org/en/latest/examples/google.html) to make a helper for developers to request their tokens from Oauth services. They just plug in the required fields, follow the instructions, and it returns their token at the end. I haven't looked at this with respect to Oauth token request processes other than Google's.

I think this could go nicely into the cookiecutter since it'll be convenient to type parameters into a file / system variable instead of calling it through the console -- see how it's used in the [tapioca-gsheets project.](https://github.com/willplaehn/tapioca-gsheets/blob/master/tapioca_gsheets/tapioca_gsheets.py)

Thanks for reviewing, and let me know if you'd like to discuss these in more detail or change the approach before considering a merge!