### PR TITLE
Set message using self in TapiocaException

### DIFF
--- a/tapioca/exceptions.py
+++ b/tapioca/exceptions.py
@@ -12,12 +12,15 @@ class TapiocaException(Exception):
     def __init__(self, message, client):
         self.status_code = None
         self.client = client
+        self.message = message
+
         if client is not None:
             self.status_code = client().status_code
 
         if not message:
-            message = "response status code: {}".format(self.status_code)
-        super(TapiocaException, self).__init__(message)
+            self.message = "response status code: {}".format(self.status_code)
+
+        super(TapiocaException, self).__init__(self.message)
 
 
 class ClientError(TapiocaException):


### PR DESCRIPTION
Fix the reason of some failing tests of related libraries under Python 3+ (for example, when testing [tapioca-cartola](https://github.com/Tiago-Lira/tapioca_cartola), some tests fail in a Python 3 environment).