### PR TITLE
Allows Arrow last version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ Documentation hosted by Readthedocs: http://tapioca-wrapper.readthedocs.io/en/st
 package = 'tapioca'
 requirements = [
     'requests>=2.6',
-    'arrow>=0.6.0,<0.7',
+    'arrow>=0.6.0,<1',
     'six>=1',
     'xmltodict>=0.9.2'
 ]


### PR DESCRIPTION
Hi there,

I changed tapioca requirements because Arrow is already in 0.10.0 version. I guess we have no problem if we allow the use of the last versions.