### PR TITLE
Fixing data returned when iterator_list is not list

### DIFF
--- a/tapioca/tapioca.py
+++ b/tapioca/tapioca.py
@@ -299,12 +299,16 @@ class TapiocaClientExecutor(TapiocaClient):
             if self._reached_max_limits(page_count, item_count, max_pages,
                                         max_items):
                 break
-            for item in iterator_list:
-                if self._reached_max_limits(page_count, item_count, max_pages,
-                                            max_items):
-                    break
-                yield self._wrap_in_tapioca(item)
-                item_count += 1
+            
+            if not isinstance(iterator_list, list):
+                yield self._wrap_in_tapioca(iterator_list)
+            else:
+                for item in iterator_list:
+                    if self._reached_max_limits(page_count, item_count, max_pages,
+                                                max_items):
+                        break
+                    yield self._wrap_in_tapioca(item)
+                    item_count += 1
 
             page_count += 1
 


### PR DESCRIPTION
### Why?
_Sometimes, the request from an API returns a dict even with pagination. The pages method expects a list, so when we iterate this method into for, it returns string slices._

### What?
_Add if else statement into pages method that verifies if iterator_list is a list. If no, it's returned iterator_list without iteration_

### How everything was tested?
_Ran code on Databricks notebook_