### PR TITLE
CI maintenance and version support changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ install:
 script:
     - tox
 python:
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"
+    - "3.9"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: focal
 language: python
 install:
     - pip install tox-travis

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,10 @@
 Changelog
 =========
 
+2.0.1
+=====
+- Updates the list of supported versions in setup.py
+
 2.0
 ===
 - Drops support for python 2.7 and 3.4

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -2,6 +2,11 @@
 Changelog
 =========
 
+2.0
+===
+- Drops support for python 2.7 and 3.4
+- Adds support for python 3.7 and 3.8
+
 1.5.1
 =====
 - Adds a ``resource_name`` kwarg to the ``get_api_root`` method

--- a/setup.py
+++ b/setup.py
@@ -74,10 +74,6 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
     ],
     test_suite='tests',
     tests_require=test_requirements

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38},coverage
+envlist = py{36,37,38,39},coverage
 
 [testenv]
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH


### PR DESCRIPTION
- This adds the missing changelog information requested in #167 and fixes CI as reported in #168. 
- Deprecates support for python 3.5
- Adds support for python 3.9