### PR TITLE
Update deprecated collections import

### DIFF
--- a/tapioca/adapters.py
+++ b/tapioca/adapters.py
@@ -2,7 +2,7 @@
 
 import json
 import xmltodict
-from collections import Mapping
+from collections.abc import Mapping
 
 from .tapioca import TapiocaInstantiator
 from .exceptions import (


### PR DESCRIPTION
Importing abstract classes directly from `collections` was deprecated and is currently raising the following warning:
`DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working`